### PR TITLE
Add docker setup and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node
+
+RUN apt-get update && apt-get install -y build-essential python
+RUN git clone https://github.com/Kitware/CMake.git /tmp/cmake
+WORKDIR /tmp/cmake
+RUN git checkout tags/v3.14.2 \
+    && ./bootstrap \
+    && make \
+    && make install
+
+RUN mkdir /opt/cfd
+WORKDIR /opt/cfd
+COPY . .
+
+# build
+RUN npm install && npm run cmake_all
+
+# test
+RUN npm run ctest

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ apt-get install -y build-essential cmake python nodejs
 cmake version 3.14.2 or lower, download from website and install cmake.
 (https://cmake.org/download/)
 
+### Docker
+
+```Shell
+# build image, dependencies and run tests
+sudo docker build -t cfd .
+
+# run container and invoke shell
+sudo docker run -it cfd bash
+```
+
 ---
 
 ## Build


### PR DESCRIPTION
This PR adds a `Dockerfile` to make setup reproducible.  The setup fails if the latest version of `CMake` is used, so this docker setup uses `CMake` version `3.14.2`.