### PR TITLE
fix: convert sighashtype on C-API

### DIFF
--- a/src/capi/cfdcapi_elements_transaction.cpp
+++ b/src/capi/cfdcapi_elements_transaction.cpp
@@ -1585,8 +1585,8 @@ int CfdAddConfidentialTxDerSign(
     }
 
     // encode to der
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     ByteData signature_bytes = ByteData(std::string(signature));
     SignParameter param(signature_bytes, true, sighashtype);
     ByteData signature_der = param.ConvertToSignature();
@@ -1772,8 +1772,8 @@ int CfdAddConfidentialTxSignWithPrivkeySimple(
 
     OutPoint outpoint(Txid(txid), vout);
     ConfidentialTransactionContext tx(tx_hex_string);
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     tx.SignWithPrivkeySimple(
         outpoint, Pubkey(pubkey), privkey_obj, sighashtype, value, addr_type,
         has_grind_r);
@@ -1874,8 +1874,8 @@ int CfdCreateConfidentialSighash(
     }
 
     ElementsTransactionApi api;
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     std::string sighash_bytes = api.CreateSignatureHash(
         std::string(tx_hex_string), Txid(std::string(txid)), vout, key_data,
         value, core_hash_type, sighashtype);
@@ -2089,8 +2089,8 @@ CFDC_API int CfdVerifyConfidentialTxSignature(
     ConfidentialTransactionController ctxc(tx_hex);
     ByteData signature_obj(signature);
     Txid txid_obj(txid);
-    SigHashType sighash_type_obj(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighash_type_obj = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     ConfidentialValue value;
     if (!IsEmptyString(value_commitment)) {
       value = ConfidentialValue(value_commitment);

--- a/src/capi/cfdcapi_key.cpp
+++ b/src/capi/cfdcapi_key.cpp
@@ -712,8 +712,8 @@ int CfdAddSighashTypeInSchnorrSignature(
           "Failed to parameter. added_signature is null or empty.");
     }
     SchnorrSignature sig(signature);
-    SigHashType sighash_type_obj(
-        static_cast<SigHashAlgorithm>(sighash_type), anyone_can_pay);
+    SigHashType sighash_type_obj = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), anyone_can_pay);
     sig.SetSigHashType(sighash_type_obj);
     *added_signature = CreateString(sig.GetData(true).GetHex());
     return CfdErrorCode::kCfdSuccess;
@@ -906,8 +906,8 @@ int CfdEncodeSignatureByDer(
           "Failed to parameter. der_signature is null.");
     }
 
-    SigHashType type = SigHashType(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType type = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     ByteData der_sig = CryptoUtil::ConvertSignatureToDer(signature, type);
     *der_signature = CreateString(der_sig.GetHex());
 

--- a/src/capi/cfdcapi_script.cpp
+++ b/src/capi/cfdcapi_script.cpp
@@ -355,8 +355,8 @@ int CfdAddMultisigScriptSigDataToDer(
     }
 
     // encode to der
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     ByteData signature_bytes = ByteData(std::string(signature));
     SignParameter param(signature_bytes, true, sighashtype);
     ByteData signature_der = param.ConvertToSignature();

--- a/src/capi/cfdcapi_transaction.cpp
+++ b/src/capi/cfdcapi_transaction.cpp
@@ -613,8 +613,8 @@ int CfdCreateSighashByHandle(
     OutPoint outpoint(Txid(txid), vout);
 
     ByteData sighash_bytes;
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     if (is_bitcoin) {
       TransactionContext* tx =
           static_cast<TransactionContext*>(tx_data->tx_obj);
@@ -746,8 +746,8 @@ int CfdAddSignWithPrivkeyByHandle(
     OutPoint outpoint(Txid(txid), vout);
 
     ByteData sighash_bytes;
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
 
     Privkey privkey_obj;
     std::string privkey_str(privkey);
@@ -891,8 +891,8 @@ int CfdAddTxSignByHandle(
     SignParameter param;
     if (use_der_encode) {
       // encode to der
-      SigHashType sighashtype(
-          static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+      SigHashType sighashtype = SigHashType::Create(
+          static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
       ByteData signature_bytes = ByteData(std::string(sign_data_hex));
       param = SignParameter(signature_bytes, true, sighashtype);
     } else {
@@ -1045,8 +1045,8 @@ int CfdAddPubkeyHashSignByHandle(
     SignParameter param;
     if (use_der_encode) {
       // encode to der
-      SigHashType sighashtype(
-          static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+      SigHashType sighashtype = SigHashType::Create(
+          static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
       ByteData signature_bytes = ByteData(std::string(signature));
       param = SignParameter(signature_bytes, true, sighashtype);
     } else {
@@ -1238,8 +1238,8 @@ int CfdAddTxSign(
     SignParameter param;
     if (use_der_encode) {
       // encode to der
-      SigHashType sighashtype(
-          static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+      SigHashType sighashtype = SigHashType::Create(
+          static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
       ByteData signature_bytes = ByteData(std::string(sign_data_hex));
       param = SignParameter(signature_bytes, true, sighashtype);
     } else {
@@ -1320,8 +1320,8 @@ int CfdAddPubkeyHashSign(
     SignParameter param;
     if (use_der_encode) {
       // encode to der
-      SigHashType sighashtype(
-          static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+      SigHashType sighashtype = SigHashType::Create(
+          static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
       ByteData signature_bytes = ByteData(std::string(signature));
       param = SignParameter(signature_bytes, true, sighashtype);
     } else {
@@ -1495,8 +1495,8 @@ int CfdAddSignWithPrivkeySimple(
     }
 
     OutPoint outpoint(Txid(txid), vout);
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
 
     bool is_bitcoin = false;
     ConvertNetType(net_type, &is_bitcoin);
@@ -1618,8 +1618,8 @@ int CfdAddMultisigSignDataToDer(
     }
 
     // encode to der
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     ByteData signature_bytes = ByteData(std::string(signature));
     SignParameter param(signature_bytes, true, sighashtype);
     ByteData signature_der = param.ConvertToSignature();
@@ -1796,8 +1796,8 @@ int CfdVerifySignature(
     WitnessVersion version = GetWitnessVersion(hash_type);
     Amount amount = Amount(value_satoshi);
     OutPoint outpoint(Txid(txid), vout);
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     ByteData signature_obj(signature);
 
     bool is_verify = false;
@@ -2011,8 +2011,8 @@ int CfdCreateSighash(
     ConvertNetType(net_type, &is_bitcoin);
     Amount value(value_satoshi);
     ByteData sighash_bytes;
-    SigHashType sighashtype(
-        static_cast<SigHashAlgorithm>(sighash_type), sighash_anyone_can_pay);
+    SigHashType sighashtype = SigHashType::Create(
+        static_cast<uint8_t>(sighash_type), sighash_anyone_can_pay);
     if ((core_hash_type == HashType::kP2sh) ||
         (core_hash_type == HashType::kP2wsh)) {
       if (IsEmptyString(redeem_script)) {


### PR DESCRIPTION
## Linked Issue

<!--
for linked ZenHub Issue or other repository issue.
  - ZenHub's issue URL
  - other repository's issue URL
-->

## Overview

- fix: convert sighashtype on C-API
  - To support sighashtype extension without extending the API.

## How to use

<!-- 
- How to check the operation
  - For tasks that require operation confirmation, enter the required commands, etc.
  - If not needed, leave blank
-->

```bash
```

## Items reserved this time, or TODO

<!--
- If not needed, leave blank
-->

## Check list

** Person who issued **
- [ ] checked script <!-- npm run check -->
- [x] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

<!--
- Explain any considerations or considerations.
-->
