### PR TITLE
fix: add error check on SplitTxOut

### DIFF
--- a/include/cfd/cfd_elements_transaction.h
+++ b/include/cfd/cfd_elements_transaction.h
@@ -203,6 +203,13 @@ class CFD_EXPORT ConfidentialTransactionContext
       bool ignore_error = false) const;
 
   /**
+   * @brief Get if it is blind.
+   * @retval true  blind
+   * @retval false unblind
+   */
+  bool HasBlinding() const;
+
+  /**
    * @brief ConfidentialTransaction's AddTxIn.
    */
   using ConfidentialTransaction::AddTxIn;

--- a/src/cfd_transaction.cpp
+++ b/src/cfd_transaction.cpp
@@ -390,6 +390,8 @@ void TransactionContext::SplitTxOut(
   if (amount_list.size() != locking_script_list.size()) {
     throw CfdException(
         CfdError::kCfdIllegalArgumentError, "Unmatch list count.");
+  } else if (amount_list.empty()) {
+    throw CfdException(CfdError::kCfdIllegalArgumentError, "list is empty.");
   }
 
   auto ref = GetTxOut(index);

--- a/test/test_cfd_confidentialtx_context.cpp
+++ b/test/test_cfd_confidentialtx_context.cpp
@@ -934,7 +934,4 @@ TEST(TransactionContext, SplitTxOutByCA)
     tx.GetHex());
 }
 
-/*
-cfd::ConfidentialTransactionContext::CallbackStateChange(unsigned int)	0
-*/
 #endif


### PR DESCRIPTION
## Linked Issue

<!--
for linked ZenHub Issue or other repository issue.
  - ZenHub's issue URL
  - other repository's issue URL
-->

## Overview

- fix: add error check on SplitTxOut
  - empty list
  - check already blinded transaction

## How to use

<!-- 
- How to check the operation
  - For tasks that require operation confirmation, enter the required commands, etc.
  - If not needed, leave blank
-->

```bash
```

## Items reserved this time, or TODO

<!--
- If not needed, leave blank
-->

## Check list

** Person who issued **
- [ ] checked script <!-- npm run check -->
- [x] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

<!--
- Explain any considerations or considerations.
-->
