### PR TITLE
fix: capi estimate fee

### DIFF
--- a/include/cfdc/cfdcapi_coin.h
+++ b/include/cfdc/cfdcapi_coin.h
@@ -166,11 +166,24 @@ CFDC_API int CfdFreeCoinSelectionHandle(
  * @brief Initialize handle for fee estimation apis.
  * @param[in] handle        cfd handle.
  * @param[out] fee_handle   handle for fee estimation apis.
+ *   Call 'CfdFreeEstimateFeeHandle' after you are finished using it.
  * @param[in] is_elements   estimate on elements chain.
  * @return CfdErrorCode
+ * @deprecated please use CfdInitializeEstimateFeeWithNetwork
  */
 CFDC_API int CfdInitializeEstimateFee(
     void* handle, void** fee_handle, bool is_elements);
+
+/**
+ * @brief Initialize handle for fee estimation apis.
+ * @param[in] handle        cfd handle.
+ * @param[in] net_type      network type.
+ * @param[out] fee_handle   handle for fee estimation apis.
+ *   Call 'CfdFreeEstimateFeeHandle' after you are finished using it.
+ * @return CfdErrorCode
+ */
+CFDC_API int CfdInitializeEstimateFeeWithNetwork(
+    void* handle, int net_type, void** fee_handle);
 
 /**
  * @brief Add Transaction Input for estimate fee handle.

--- a/include/cfdc/cfdcapi_coin.h
+++ b/include/cfdc/cfdcapi_coin.h
@@ -281,11 +281,31 @@ CFDC_API int CfdSetOptionEstimateFee(
  * @param[in] is_blind              need blind later.
  * @param[in] effective_fee_rate    effective fee rate for estimation.
  * @return CfdErrorCode
+ * @deprecated please use CfdGetEstimateFee
  */
 CFDC_API int CfdFinalizeEstimateFee(
     void* handle, void* fee_handle, const char* tx_hex, const char* fee_asset,
     int64_t* txout_fee, int64_t* utxo_fee, bool is_blind,
     double effective_fee_rate);
+
+/**
+ * @brief Get fee estimation api call.
+ * @param[in] handle                cfd handle.
+ * @param[in] fee_handle            handle for fee estimation apis.
+ * @param[in] tx_hex                transaction hex.
+ * @param[in] fee_asset             asset id used as fee.
+ * @param[in] is_blind              need blind later.
+ * @param[in] effective_fee_rate    effective fee rate for estimation.
+ * @param[out] txout_fee            estimated fee by transaction base & output.
+ *     (not contain utxo_fee.)
+ * @param[out] utxo_fee             estimated fee by input utxos.
+ *     (not contain txout_fee.)
+ * @return CfdErrorCode
+ */
+CFDC_API int CfdGetEstimateFee(
+    void* handle, void* fee_handle, const char* tx_hex, const char* fee_asset,
+    bool is_blind, double effective_fee_rate,
+    int64_t* txout_fee, int64_t* utxo_fee);
 
 /**
  * @brief Free handle for fee estimation

--- a/local_resource/external_project_local_setting.config
+++ b/local_resource/external_project_local_setting.config
@@ -1,4 +1,4 @@
-CFD_VERSION=0.4.6
+CFD_VERSION=0.4.8
 CFDCORE_TARGET_VERSION=refs/tags/v0.4.5
 LIBWALLY_TARGET_VERSION=refs/tags/cfd-0.4.8
 CFDCORE_TARGET_URL=cryptogarageinc/cfd-core.git

--- a/src/capi/cfdcapi_coin.cpp
+++ b/src/capi/cfdcapi_coin.cpp
@@ -595,6 +595,12 @@ int CfdFreeCoinSelectionHandle(void* handle, void* coin_select_handle) {
 
 int CfdInitializeEstimateFee(
     void* handle, void** fee_handle, bool is_elements) {
+  int net_type = (is_elements) ? kCfdNetworkLiquidv1 : kCfdNetworkMainnet;
+  return CfdInitializeEstimateFeeWithNetwork(handle, net_type, fee_handle);
+}
+
+int CfdInitializeEstimateFeeWithNetwork(
+    void* handle, int net_type, void** fee_handle) {
   CfdCapiEstimateFeeData* buffer = nullptr;
   try {
     cfd::Initialize();
@@ -604,6 +610,7 @@ int CfdInitializeEstimateFee(
           CfdError::kCfdIllegalArgumentError,
           "Failed to parameter. Fee handle is null.");
     }
+    bool is_elements = cfd::capi::IsElementsNetType(net_type);
 
     buffer = static_cast<CfdCapiEstimateFeeData*>(
         AllocBuffer(kPrefixEstimateFeeData, sizeof(CfdCapiEstimateFeeData)));

--- a/src/capi/cfdcapi_coin.cpp
+++ b/src/capi/cfdcapi_coin.cpp
@@ -778,6 +778,14 @@ int CfdFinalizeEstimateFee(
     void* handle, void* fee_handle, const char* tx_hex, const char* fee_asset,
     int64_t* txout_fee, int64_t* utxo_fee, bool is_blind,
     double effective_fee_rate) {
+  return CfdGetEstimateFee(handle, fee_handle, tx_hex, fee_asset,
+      is_blind, effective_fee_rate, txout_fee, utxo_fee);
+}
+
+int CfdGetEstimateFee(
+    void* handle, void* fee_handle, const char* tx_hex, const char* fee_asset,
+    bool is_blind, double effective_fee_rate,
+    int64_t* txout_fee, int64_t* utxo_fee) {
   try {
     cfd::Initialize();
     CheckBuffer(fee_handle, kPrefixEstimateFeeData);

--- a/src/capi/cfdcapi_coin.cpp
+++ b/src/capi/cfdcapi_coin.cpp
@@ -610,14 +610,15 @@ int CfdInitializeEstimateFeeWithNetwork(
           CfdError::kCfdIllegalArgumentError,
           "Failed to parameter. Fee handle is null.");
     }
-    bool is_elements = cfd::capi::IsElementsNetType(net_type);
 
     buffer = static_cast<CfdCapiEstimateFeeData*>(
         AllocBuffer(kPrefixEstimateFeeData, sizeof(CfdCapiEstimateFeeData)));
     buffer->input_utxos = new std::vector<UtxoData>();
 #ifndef CFD_DISABLE_ELEMENTS
-    buffer->is_elements = is_elements;
+    buffer->is_elements = cfd::capi::IsElementsNetType(net_type);
     buffer->input_elements_utxos = new std::vector<ElementsUtxoAndOption>();
+#else
+    info(CFD_LOG_SOURCE, "net_type={}", net_type);
 #endif                                               // CFD_DISABLE_ELEMENTS
     buffer->minimum_bits = cfd::capi::kMinimumBits;  // old(36)
 


### PR DESCRIPTION
## Linked Issue

<!--
for linked ZenHub Issue or other repository issue.
  - ZenHub's issue URL
  - other repository's issue URL
-->

## Overview

- fix: capi estimate fee (for python)
  - add CfdInitializeEstimateFeeWithNetwork and CfdGetEstimateFee

## How to use

<!-- 
- How to check the operation
  - For tasks that require operation confirmation, enter the required commands, etc.
  - If not needed, leave blank
-->

```bash
```

## Items reserved this time, or TODO

<!--
- If not needed, leave blank
-->

## Check list

** Person who issued **
- [ ] checked script <!-- npm run check -->
- [x] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

<!--
- Explain any considerations or considerations.
-->
